### PR TITLE
Ice and Fire repair materials patch

### DIFF
--- a/src/main/java/com/mordenkainen/sproutpatcher/SproutConfig.java
+++ b/src/main/java/com/mordenkainen/sproutpatcher/SproutConfig.java
@@ -10,6 +10,7 @@ public class SproutConfig {
     public static boolean CabinetPatch = true;
     public static boolean SoundPatch = true;
     public static boolean RCPatch = true;
+    public static boolean IceAndFirePatch = true;
     
     static void loadConfig(File configFile) {
         ConfigFile config = new ConfigFile(configFile).setComment("SproutPatcher configuration file.");
@@ -18,5 +19,6 @@ public class SproutConfig {
         CabinetPatch = config.getTag("RusticCabinet").setComment("Patch Rustic Cabinet Rendering to prevent crash.").getBooleanValue(CabinetPatch);
         RCPatch = config.getTag("RecurrentComplex").setComment("Patch Recurrent Complex Script block Redstone Handling.").getBooleanValue(RCPatch);
         SoundPatch = config.getTag("SoundPatch").setComment("Patch soundsystem crash.").getBooleanValue(SoundPatch);
+        IceAndFirePatch = config.getTag("IceAndFire").setComment("Patch Ice And Fire tool repair materials to prevent crash and allow tool repairs.").getBooleanValue(IceAndFirePatch);
     }
 }

--- a/src/main/java/com/mordenkainen/sproutpatcher/SproutPatcherCoreTransformer.java
+++ b/src/main/java/com/mordenkainen/sproutpatcher/SproutPatcherCoreTransformer.java
@@ -4,13 +4,14 @@ import com.mordenkainen.sproutpatcher.patches.BedPatcher;
 import com.mordenkainen.sproutpatcher.patches.BotaniaPatcher;
 import com.mordenkainen.sproutpatcher.patches.CabinetPatcher;
 import com.mordenkainen.sproutpatcher.patches.IPatch;
+import com.mordenkainen.sproutpatcher.patches.IceAndFirePatcher;
 import com.mordenkainen.sproutpatcher.patches.ReComplexPatcher;
 import com.mordenkainen.sproutpatcher.patches.SoundPatcher;
 
 import net.minecraft.launchwrapper.IClassTransformer;
 
 public class SproutPatcherCoreTransformer implements IClassTransformer {
-    private static IPatch[] patches= {new CabinetPatcher(), new ReComplexPatcher(), new BotaniaPatcher(), new SoundPatcher(), new BedPatcher()};
+    private static IPatch[] patches= {new CabinetPatcher(), new ReComplexPatcher(), new BotaniaPatcher(), new SoundPatcher(), new BedPatcher(), new IceAndFirePatcher()};
     
     @Override
     public byte[] transform(final String name, final String transformedName, byte[] basicClass) {

--- a/src/main/java/com/mordenkainen/sproutpatcher/patches/IceAndFirePatcher.java
+++ b/src/main/java/com/mordenkainen/sproutpatcher/patches/IceAndFirePatcher.java
@@ -1,0 +1,48 @@
+package com.mordenkainen.sproutpatcher.patches;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import com.github.alexthe666.iceandfire.core.ModItems;
+import com.mordenkainen.sproutpatcher.SproutConfig;
+import com.mordenkainen.sproutpatcher.asmhelper.ASMHelper;
+
+import net.minecraft.item.ItemStack;
+
+public class IceAndFirePatcher implements IPatch {
+    
+    @Override
+    public boolean shouldLoad() {
+        return SproutConfig.IceAndFirePatch;
+    }
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if ("com.github.alexthe666.iceandfire.core.ModItems".equals(transformedName)) {
+            final ClassNode classNode = ASMHelper.readClassFromBytes(basicClass);
+            final MethodNode method = ASMHelper.findMethodNodeOfClass(classNode, "init", "()V");
+
+            if (method != null) {
+                AbstractInsnNode targetNode = ASMHelper.findLastInstructionWithOpcode(method, Opcodes.RETURN);
+                if (targetNode != null) {
+                    method.instructions.insertBefore(targetNode, new MethodInsnNode(Opcodes.INVOKESTATIC, "com/mordenkainen/sproutpatcher/patches/IceAndFirePatcher", "setRepairMaterials", "()V", false));
+                    
+                }
+            }
+            
+            return ASMHelper.writeClassToBytes(classNode);
+        }
+        return basicClass;
+    }
+
+    public static void setRepairMaterials() {
+        ModItems.silverTools.setRepairItem(new ItemStack(ModItems.silverIngot));
+        ModItems.boneTools.setRepairItem(new ItemStack(ModItems.dragonbone));
+        ModItems.fireBoneTools.setRepairItem(new ItemStack(ModItems.dragonbone));
+        ModItems.iceBoneTools.setRepairItem(new ItemStack(ModItems.dragonbone));
+    }
+
+}


### PR DESCRIPTION
This patch adds repair materials to Ice and Fire tools and stops the crash when Minecraft looks for whether a repair material is valid when putting those tools in an anvil.