### PR TITLE
Change SoundPatch to default to false now that it has been backported…

### DIFF
--- a/src/main/java/com/mordenkainen/sproutpatcher/SproutConfig.java
+++ b/src/main/java/com/mordenkainen/sproutpatcher/SproutConfig.java
@@ -8,7 +8,7 @@ public class SproutConfig {
     public static boolean BedPatch = true;
     public static boolean BotaniaPatch = true;
     public static boolean CabinetPatch = true;
-    public static boolean SoundPatch = true;
+    public static boolean SoundPatch = false;
     public static boolean RCPatch = true;
     public static boolean IceAndFirePatch = true;
     


### PR DESCRIPTION
… into Ambient Sounds 1.10.2 to prevent crash if one attempts to load both patches.